### PR TITLE
[SYAL-2348] The N/A values are not displayed for buttons in the Historical Properties

### DIFF
--- a/src/main/java/com/avispl/symphony/dal/infrastructure/management/brightsign/bsncloud/BrightSignBSNCloudCommunicator.java
+++ b/src/main/java/com/avispl/symphony/dal/infrastructure/management/brightsign/bsncloud/BrightSignBSNCloudCommunicator.java
@@ -969,8 +969,8 @@ public class BrightSignBSNCloudCommunicator extends RestCommunicator implements 
 	 * @param advancedControllableProperties A list of AdvancedControllableProperty objects to be populated with controllable properties.
 	 */
 	private void mapControllableProperty(Map<String, String> stats, List<AdvancedControllableProperty> advancedControllableProperties) {
-		addAdvancedControlProperties(advancedControllableProperties, stats, createButton(BrightSignBSNCloudConstant.REBOOT_PLAYER, "Reboot", "Rebooting", 0), BrightSignBSNCloudConstant.NONE);
-		addAdvancedControlProperties(advancedControllableProperties, stats, createButton(BrightSignBSNCloudConstant.REBOOT_WITH_CRASH_REPORT, "Reboot", "Rebooting", 0), BrightSignBSNCloudConstant.NONE);
+		addAdvancedControlProperties(advancedControllableProperties, stats, createButton(BrightSignBSNCloudConstant.REBOOT_PLAYER, "Reboot", "Rebooting", 0), BrightSignBSNCloudConstant.NOT_AVAILABLE);
+		addAdvancedControlProperties(advancedControllableProperties, stats, createButton(BrightSignBSNCloudConstant.REBOOT_WITH_CRASH_REPORT, "Reboot", "Rebooting", 0), BrightSignBSNCloudConstant.NOT_AVAILABLE);
 	}
 
 	/**

--- a/src/main/java/com/avispl/symphony/dal/infrastructure/management/brightsign/bsncloud/common/BrightSignBSNCloudConstant.java
+++ b/src/main/java/com/avispl/symphony/dal/infrastructure/management/brightsign/bsncloud/common/BrightSignBSNCloudConstant.java
@@ -15,7 +15,7 @@ public class BrightSignBSNCloudConstant {
 	public static final String HASH = "#";
 	public static final String MODEL_MAPPING_AGGREGATED_DEVICE = "brightsign/model-mapping.yml";
 	public static final String NONE = "None";
-	public static final String SPACE = " ";
+	public static final String NOT_AVAILABLE = "N/A";
 	public static final String EMPTY = "";
 	public static final String TRUE = "true";
 	public static final String FALSE = "false";


### PR DESCRIPTION
- Description: The N/A values should be displayed for buttons in the Historical Properties, as mentioned in the Guidelines:
   - RebootPlayer
   - RebootWithCrashReport
- Result:
   - Before
   <img width="454" height="218" alt="ảnh" src="https://github.com/user-attachments/assets/19074d5d-095c-4650-a181-6f99e6e84afe" />

   - After
   <img width="596" height="560" alt="ảnh" src="https://github.com/user-attachments/assets/96dc6eaa-5a36-4f48-8bf3-c1a0912e17a4" />